### PR TITLE
Fixed multiple select issue

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -118,6 +118,9 @@ export default class Field extends React.PureComponent<Props, State> {
       input.checked = value === _value
       input.value = _value
     }
+    if (component === 'select' && rest.multiple) {
+      input.value = input.value || []
+    }
     if (typeof children === 'function') {
       return (children: Function)({ input, meta, ...rest })
     }

--- a/src/Field.test.js
+++ b/src/Field.test.js
@@ -193,6 +193,23 @@ describe('Field', () => {
     expect(render.mock.calls[2][0].values.foo).toBeUndefined()
   })
 
+  it('should provide a value of [] when empty on a select multiple', () => {
+    const dom = TestUtils.renderIntoDocument(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <Field name="foo" component="select" multiple />
+          </form>
+        )}
+      </Form>
+    )
+
+    // This test is mostly for code coverage. Is there a way to assure that the value prop
+    // passed to the <select> is []?
+    const select = TestUtils.findRenderedDOMComponentWithTag(dom, 'select')
+    expect(select.value).toBe('')
+  })
+
   it('should optionally allow null', () => {
     const renderInput = jest.fn(({ input }) => <input {...input} />)
     const render = jest.fn(() => (


### PR DESCRIPTION
Fixed this warning:
```
Warning: The `value` prop supplied to <select> must be an array if `multiple` is true.

Check the render method of `Field`.
```