### PR TITLE
Added missing initialize prop to FormRenderProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,16 @@ A function to focus (mark active) any field.
 A function intended for you to give directly to the `<form>` tag: `<form
 onSubmit={handleSubmit}/>`.
 
+#### `initialize: (values: Object) => void`
+
+A function that initializes the form values.
+[See the 🏁 Final Form docs on `initialize`](https://github.com/erikras/final-form#initialize-values-object--void).
+
+#### `reset: () => void`
+
+A function that resets the form values to their last initialized values.
+[See the 🏁 Final Form docs on `reset`](https://github.com/erikras/final-form#reset---void).
+
 ### `FormSpyProps`
 
 These are the props that you pass to

--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -112,6 +112,7 @@ export default class ReactFinalForm extends React.PureComponent<Props, State> {
         change: this.form && this.form.change,
         focus: this.form && this.form.focus,
         handleSubmit: this.handleSubmit,
+        initialize: this.form && this.form.initialize,
         reset: this.form && this.form.reset
       },
       'ReactFinalForm'

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -41,6 +41,7 @@ export type FormRenderProps = {
   change: (name: string, value: any) => void,
   focus: (name: string) => void,
   handleSubmit: (SyntheticEvent<HTMLFormElement>) => void,
+  initialize: (values: Object) => void,
   reset: () => void
 }
 


### PR DESCRIPTION
Oops. Left out a `initialize()` and left `reset()` out of the docs. Fixed.